### PR TITLE
Add role-based authentication and session-protected activity management

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pytest
+httpx

--- a/src/app.py
+++ b/src/app.py
@@ -5,14 +5,21 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+from pydantic import BaseModel
+import secrets
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
@@ -77,10 +84,107 @@ activities = {
     }
 }
 
+# In-memory users and sessions (for exercise purposes only)
+users = {
+    "admin": {
+        "password": "admin123",
+        "role": "Administrator",
+        "email": "admin@mergington.edu"
+    },
+    "faculty1": {
+        "password": "faculty123",
+        "role": "Faculty",
+        "email": "faculty1@mergington.edu"
+    },
+    "student1": {
+        "password": "student123",
+        "role": "Student",
+        "email": "student1@mergington.edu"
+    }
+}
+
+# Maps bearer token -> username
+sessions = {}
+
+
+def _extract_bearer_token(authorization: str | None) -> str:
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(status_code=401, detail="Invalid authentication format")
+
+    return token
+
+
+def get_current_user(authorization: str | None = Header(default=None)):
+    token = _extract_bearer_token(authorization)
+    username = sessions.get(token)
+
+    if not username:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    user = users.get(username)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid session user")
+
+    return {
+        "token": token,
+        "username": username,
+        "role": user["role"],
+        "email": user["email"]
+    }
+
+
+def require_roles(*allowed_roles: str):
+    def role_checker(current_user=Depends(get_current_user)):
+        if current_user["role"] not in allowed_roles:
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+        return current_user
+
+    return role_checker
+
 
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
+
+
+@app.post("/auth/login")
+def login(payload: LoginRequest):
+    user = users.get(payload.username)
+    if not user or user["password"] != payload.password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = secrets.token_urlsafe(24)
+    sessions[token] = payload.username
+
+    return {
+        "message": "Login successful",
+        "access_token": token,
+        "token_type": "bearer",
+        "user": {
+            "username": payload.username,
+            "role": user["role"],
+            "email": user["email"]
+        }
+    }
+
+
+@app.post("/auth/logout")
+def logout(current_user=Depends(get_current_user)):
+    sessions.pop(current_user["token"], None)
+    return {"message": "Logout successful"}
+
+
+@app.get("/auth/me")
+def me(current_user=Depends(get_current_user)):
+    return {
+        "username": current_user["username"],
+        "role": current_user["role"],
+        "email": current_user["email"]
+    }
 
 
 @app.get("/activities")
@@ -89,8 +193,14 @@ def get_activities():
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    current_user=Depends(require_roles("Administrator", "Faculty"))
+):
     """Sign up a student for an activity"""
+    _ = current_user
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +221,14 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    current_user=Depends(require_roles("Administrator", "Faculty"))
+):
     """Unregister a student from an activity"""
+    _ = current_user
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,62 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const loginForm = document.getElementById("login-form");
+  const logoutBtn = document.getElementById("logout-btn");
+  const authStatus = document.getElementById("auth-status");
+
+  let accessToken = localStorage.getItem("accessToken");
+  let currentUser = null;
+
+  function getRole() {
+    return currentUser?.role || null;
+  }
+
+  function canManageActivities() {
+    const role = getRole();
+    return role === "Administrator" || role === "Faculty";
+  }
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function getAuthHeaders() {
+    if (!accessToken) {
+      return {};
+    }
+
+    return {
+      Authorization: `Bearer ${accessToken}`,
+    };
+  }
+
+  function updateAuthUI() {
+    if (currentUser) {
+      authStatus.textContent = `Logged in as ${currentUser.username} (${currentUser.role})`;
+      authStatus.className = "auth-status info";
+      authStatus.classList.remove("hidden");
+      logoutBtn.classList.remove("hidden");
+      loginForm.classList.add("hidden");
+    } else {
+      authStatus.textContent = "Not logged in";
+      authStatus.className = "auth-status info";
+      authStatus.classList.remove("hidden");
+      logoutBtn.classList.add("hidden");
+      loginForm.classList.remove("hidden");
+    }
+
+    const isManager = canManageActivities();
+    signupForm.querySelectorAll("input, select, button").forEach((element) => {
+      element.disabled = !isManager;
+    });
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +68,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
+
+      const showDeleteButtons = canManageActivities();
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +89,14 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li>
+                        <span class="participant-email">${email}</span>
+                        ${
+                          showDeleteButtons
+                            ? `<button class="delete-btn" data-activity="${name}" data-email="${email}" title="Unregister student">❌</button>`
+                            : ""
+                        }
+                      </li>`
                   )
                   .join("")}
               </ul>
@@ -69,6 +135,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!canManageActivities()) {
+      showMessage("Only Administrator and Faculty accounts can unregister students.", "error");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -80,39 +151,124 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: {
+            ...getAuthHeaders(),
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
+  }
+
+  // Handle login form submission
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("username").value.trim();
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Login failed", "error");
+        return;
+      }
+
+      accessToken = result.access_token;
+      currentUser = result.user;
+      localStorage.setItem("accessToken", accessToken);
+      loginForm.reset();
+      updateAuthUI();
+      await fetchActivities();
+      showMessage(result.message, "success");
+    } catch (error) {
+      console.error("Login failed:", error);
+      showMessage("Failed to log in. Please try again.", "error");
+    }
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      if (accessToken) {
+        await fetch("/auth/logout", {
+          method: "POST",
+          headers: {
+            ...getAuthHeaders(),
+          },
+        });
+      }
+    } catch (error) {
+      console.error("Logout request failed:", error);
+    } finally {
+      accessToken = null;
+      currentUser = null;
+      localStorage.removeItem("accessToken");
+      updateAuthUI();
+      await fetchActivities();
+      showMessage("Logged out", "info");
+    }
+  });
+
+  async function initializeSession() {
+    if (!accessToken) {
+      updateAuthUI();
+      await fetchActivities();
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/me", {
+        headers: {
+          ...getAuthHeaders(),
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("Invalid session");
+      }
+
+      currentUser = await response.json();
+    } catch (error) {
+      console.error("Session restore failed:", error);
+      accessToken = null;
+      currentUser = null;
+      localStorage.removeItem("accessToken");
+    }
+
+    updateAuthUI();
+    await fetchActivities();
   }
 
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
+
+    if (!canManageActivities()) {
+      showMessage("Only Administrator and Faculty accounts can register students.", "error");
+      return;
+    }
 
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
@@ -124,37 +280,29 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: {
+            ...getAuthHeaders(),
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
   // Initialize app
-  fetchActivities();
+  initializeSession();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,22 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <section id="auth-panel">
+        <h3>Account Access</h3>
+        <form id="login-form">
+          <div class="auth-row">
+            <label for="username">Username</label>
+            <input type="text" id="username" required placeholder="admin / faculty1 / student1" />
+          </div>
+          <div class="auth-row">
+            <label for="password">Password</label>
+            <input type="password" id="password" required placeholder="Enter password" />
+          </div>
+          <button type="submit">Log In</button>
+        </form>
+        <div id="auth-status" class="hidden"></div>
+        <button id="logout-btn" class="hidden">Log Out</button>
+      </section>
     </header>
 
     <main>
@@ -22,7 +38,8 @@
       </section>
 
       <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
+        <h3>Register Students for an Activity</h3>
+        <p class="hint-text">Only Administrator and Faculty accounts can register or remove participants.</p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -28,6 +28,48 @@ header h1 {
   margin-bottom: 10px;
 }
 
+#auth-panel {
+  margin: 16px auto 0;
+  max-width: 520px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 8px;
+  padding: 14px;
+  text-align: left;
+}
+
+#auth-panel h3 {
+  margin-bottom: 10px;
+  color: #fff;
+  border: none;
+  padding: 0;
+}
+
+#login-form {
+  display: grid;
+  gap: 10px;
+}
+
+.auth-row {
+  display: grid;
+  gap: 4px;
+}
+
+.auth-row input {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #d9defa;
+  border-radius: 4px;
+}
+
+.auth-status {
+  margin-top: 10px;
+}
+
+#logout-btn {
+  margin-top: 10px;
+}
+
 main {
   display: flex;
   flex-wrap: wrap;
@@ -55,6 +97,11 @@ section h3 {
   padding-bottom: 10px;
   border-bottom: 1px solid #ddd;
   color: #1a237e;
+}
+
+.hint-text {
+  margin-bottom: 14px;
+  color: #555;
 }
 
 .activity-card {
@@ -162,6 +209,13 @@ button {
 
 button:hover {
   background-color: #3949ab;
+}
+
+button:disabled,
+input:disabled,
+select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .message {

--- a/tests/test_auth_rbac.py
+++ b/tests/test_auth_rbac.py
@@ -1,0 +1,95 @@
+from copy import deepcopy
+
+from fastapi.testclient import TestClient
+
+from src.app import activities, app, sessions
+
+
+client = TestClient(app)
+
+
+def login_as(username: str, password: str) -> str:
+    response = client.post(
+        "/auth/login",
+        json={"username": username, "password": password},
+    )
+    assert response.status_code == 200
+    return response.json()["access_token"]
+
+
+def setup_function() -> None:
+    sessions.clear()
+    setup_function.activities_snapshot = deepcopy(activities)
+
+
+def teardown_function() -> None:
+    sessions.clear()
+    activities.clear()
+    activities.update(deepcopy(setup_function.activities_snapshot))
+
+
+def test_login_success_and_profile() -> None:
+    response = client.post(
+        "/auth/login",
+        json={"username": "admin", "password": "admin123"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    token = body["access_token"]
+    assert body["user"]["role"] == "Administrator"
+
+    me_response = client.get(
+        "/auth/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert me_response.status_code == 200
+    assert me_response.json()["username"] == "admin"
+
+
+def test_login_failure_rejected() -> None:
+    response = client.post(
+        "/auth/login",
+        json={"username": "admin", "password": "wrong-password"},
+    )
+    assert response.status_code == 401
+
+
+def test_signup_requires_authentication() -> None:
+    response = client.post("/activities/Chess%20Club/signup?email=tester@mergington.edu")
+    assert response.status_code == 401
+
+
+def test_student_cannot_signup_or_unregister() -> None:
+    student_token = login_as("student1", "student123")
+    headers = {"Authorization": f"Bearer {student_token}"}
+
+    signup_response = client.post(
+        "/activities/Chess%20Club/signup?email=student-blocked@mergington.edu",
+        headers=headers,
+    )
+    assert signup_response.status_code == 403
+
+    unregister_response = client.delete(
+        "/activities/Chess%20Club/unregister?email=michael@mergington.edu",
+        headers=headers,
+    )
+    assert unregister_response.status_code == 403
+
+
+def test_faculty_can_signup_and_unregister() -> None:
+    faculty_token = login_as("faculty1", "faculty123")
+    headers = {"Authorization": f"Bearer {faculty_token}"}
+    email = "new.student@mergington.edu"
+
+    signup_response = client.post(
+        f"/activities/Chess%20Club/signup?email={email}",
+        headers=headers,
+    )
+    assert signup_response.status_code == 200
+
+    unregister_response = client.delete(
+        f"/activities/Chess%20Club/unregister?email={email}",
+        headers=headers,
+    )
+    assert unregister_response.status_code == 200


### PR DESCRIPTION
## Summary
This PR implements issue #8 by adding role-based authentication, session management, and route-level authorization checks across API and UI.

## What Changed
- Added API auth endpoints:
  - `POST /auth/login`
  - `POST /auth/logout`
  - `GET /auth/me`
- Added in-memory users with explicit roles:
  - `Administrator`, `Faculty`, `Student`
- Added bearer-token session store and validation.
- Protected write operations with RBAC:
  - `POST /activities/{activity_name}/signup` requires `Administrator` or `Faculty`
  - `DELETE /activities/{activity_name}/unregister` requires `Administrator` or `Faculty`
- Updated frontend with login/logout controls and role-aware behavior:
  - Restores session from `localStorage`
  - Sends bearer token for protected actions
  - Disables signup/unregister UI for unauthorized roles
  - Displays auth status and user role
- Added tests for success and rejection paths.

## Tests
Executed locally:
- `/usr/local/bin/python -m pytest -q`
- Result: `5 passed`

## Notes
- Current credentials are in-memory for this exercise and can be replaced by persistent user storage in a follow-up change.